### PR TITLE
python3 support

### DIFF
--- a/CSIntel.py
+++ b/CSIntel.py
@@ -2,12 +2,12 @@
 
 """
 This file will act as a Python API for CrowdStrike's Threat Intelligence API. It was built to make it
-easy to use the Intel API. 
+easy to use the Intel API.
 
-This module can be used one of two ways: by executing it directly from the command line or by importing 
-it into another script. 
+This module can be used one of two ways: by executing it directly from the command line or by importing
+it into another script.
 
-Example 1: 
+Example 1:
     $> ./CSIntel.py --custid ABC --custkey DEF --day --indicators
 
 Example 2:
@@ -89,8 +89,8 @@ and your Customer Key. There are two ways you can do this:
     expected is ~/.csintel.ini
 
     In order to create this config file you can either write it explicitly or save the config from the
-    command line executation. 
-        $> ./CSintel.py --custid ABCD --custkey EFGH --write 
+    command line executation.
+        $> ./CSintel.py --custid ABCD --custkey EFGH --write
 
     This will save Customer ID & Key to the default config file (csintel.ini). If you wish to specify
     a different file you can pass that: --write --config diffFile.ini
@@ -101,7 +101,7 @@ and your Customer Key. There are two ways you can do this:
         custid = ABCD
         custkey = EFGH
 
-Once you are setup to pass your Customer ID and Key you can start searching the Threat Intel API. 
+Once you are setup to pass your Customer ID and Key you can start searching the Threat Intel API.
 
 You can also specify what output you want to receive. By default these methods will pretty print all
 JSON received from the API request. Altenatively you can specify:
@@ -169,18 +169,18 @@ except Exception:     # python2
     import urllib
 
 
-#Global
+# Global
 CSconfigSection = "CrowdStrikeIntelAPI"
 host = "https://intelapi.crowdstrike.com/indicator/v1/search/"
-defaultConfigFileName = os.path.join( os.path.expanduser("~"), ".csintel.ini" )
+defaultConfigFileName = os.path.join(os.path.expanduser("~"), ".csintel.ini")
 
-#setup
+# setup
 __author__ = "Adam Hogan"
 __email__ = "adam.hogan@crowdstrike.com"
 __version__ = '0.7.2'
 
-#I should do more with this....
-#These specs from the API documentation should be used to do more input validation
+# I should do more with this....
+# These specs from the API documentation should be used to do more input validation
 validType = ['binary_string', 'compile_time', 'device_name', 'domain', 'email_address', 'email_subject', 'event_name', 'file_mapping', 'file_name', 'file_path', 'hash_ion', 'hash_md5', 'hash_sha1', 'hash_sha256', 'ip_address', 'ip_address_block', 'mutex_name', 'password', 'persona_name', 'phone_number', 'port', 'registry', 'semaphore_name', 'service_name', 'url', 'user_agent', 'username', 'x509_serial', 'x509_subject']
 validParameter = ['sort', 'order', 'last_updated', 'perPage', 'page']
 validSearch = ['indicator', 'actor', 'report', 'actor', 'malicious_confidence', 'published_date', 'last_updated', 'malware_family', 'kill_chain', 'domain_type']
@@ -188,32 +188,33 @@ validDomainType = ['Actor Controlled', 'DGA', 'DynamicDNS', 'DynamicDNS/Afraid',
 validFilter = ['match', 'equal', 'gt', 'gte', 'lt', 'lte']
 validSort = ['indicator', 'type', 'report', 'actor', 'malicious_confidence', 'published_date', 'last_updated']
 
-#local methods 
+
+# local methods
 def readConfig(fileName=None):
     """this method is usef for initial creation and can be called
     before an API object is created. Just pass it the filename
     to read an existing config file."""
 
-    #check file exists
-    if (os.path.exists(fileName)) == False:
+    # check file exists
+    if (os.path.exists(fileName)) is False:
         raise Exception("Config file does not exist: " + fileName)
 
-        
-    #read config file
+    # read config file
     parser = SafeConfigParser()
-    parser.read( fileName )
+    parser.read(fileName)
 
-    #get var [custid, custkey]
+    # get var [custid, custkey]
     section = CSconfigSection
     custid = parser.get(section, "custid")
     custkey = parser.get(section, "custkey")
     perpage = parser.get(section, "perpage")
 
-    #TODO might need error checking on what is or isn't being pulled
-    #from the file down the road. 
+    # TODO might need error checking on what is or isn't being pulled
+    # from the file down the road.
 
     return (custid, custkey, perpage)
-#end readConfig()
+# end readConfig()
+
 
 ######################################################################
 class CSIntelAPI:
@@ -222,12 +223,12 @@ class CSIntelAPI:
 
     This class object is used in this program if called directly or can be imported
     into another script to use it's methods to search the threat intel API and process
-    the data returned. 
+    the data returned.
 
     Check out functions that start with Search* to see different methods of pulling data.
 
     Check out functions that like Get*FromResults to see different exampels of processing
-    the JSON data that is returned from an API search. 
+    the JSON data that is returned from an API search.
 
     To create this object you need to pass your Customer ID and Cutomer Key. If you're
     going to be reusing this at all it is much faster to add your ID & Key to a config
@@ -245,35 +246,34 @@ class CSIntelAPI:
 
     And then manipulate the results.
 
-        data = json.loads( result.text )
+        data = json.loads(result.text)
 
     Or use some of the built in methods.
 
         hashes = api_obj.GetHashesFromResults(data)
     """
 
-
     def __init__(self, custid=None, custkey=None, perpage=None, page="1", debug=False):
         """
         Intit funciton for the CS Intel API object - pass it the API customer ID and
-        customer key to create it. 
-        Optional: whether the config should be written to disk as a config ini file. 
+        customer key to create it.
+        Optional: whether the config should be written to disk as a config ini file.
         If the config file is being used check out the readConfig() function to grab
-        those fields before creating this object. 
+        those fields before creating this object.
         """
 
-        #customer id and key should be passed when obj is created
+        # customer id and key should be passed when obj is created
         self.custid = custid
         self.custkey = custkey
 
-        #pull some global settings for object reference
-        self.configSection = CSconfigSection #config file section title
-        self.host = host #hostname of where to query API 
+        # pull some global settings for object reference
+        self.configSection = CSconfigSection  # config file section title
+        self.host = host                      # hostname of where to query API
         self.perpage = perpage
         self.page = page
 
-        #set API valid terms
-        #should be used more for syntax validation.
+        # set API valid terms
+        # should be used more for syntax validation.
         self.validType = validType
         self.ValidParameter = validParameter
         self.validSearch = validSearch
@@ -281,11 +281,10 @@ class CSIntelAPI:
         self.validSort = validSort
         self.validDomainType = validDomainType
 
-        #debug?
+        # debug?
         self.debug = debug
 
-    #end init
-
+    # end init
 
     def writeConfig(self, fileName=None):
         """
@@ -296,40 +295,39 @@ class CSIntelAPI:
         you have loaded.
         """
 
-        #setup 
-        section = self.configSection #config section to use
-        parser = SafeConfigParser()  #create object from ConfigParser library import
-        
-        #create config file data
-        #create proper section and then add customer id and key as entries. 
-        parser.add_section( section )
+        # setup
+        section = self.configSection  # config section to use
+        parser = SafeConfigParser()   # create object from ConfigParser library import
+
+        # create config file data
+        # create proper section and then add customer id and key as entries.
+        parser.add_section(section)
         parser.set(section, 'custid', self.custid)
         parser.set(section, 'custkey', self.custkey)
         parser.set(section, 'perpage', self.perPage)
 
-        #write to disk
+        # write to disk
         f = open(fileName, "w")
         parser.write(f)
         f.close()
-    #end writeConfig()    
+    # end writeConfig()
 
     def getHeaders(self):
         """
         Need to pass customer id and key as headers.
         This will return the correct syntax to do so. These fields need to be
-        passed as headers and not in the URL request itself. 
+        passed as headers and not in the URL request itself.
         headers = {'X-CSIX-CUSTID': custid, 'X-CSIX-CUSTKEY': custkey}
         """
         headers = {'X-CSIX-CUSTID': self.custid, 'X-CSIX-CUSTKEY': self.custkey}
-        #this is the format needed by the requests module
+        # this is the format needed by the requests module
         return headers
-    #end getHeaders
-
+    # end getHeaders
 
     def request(self, query):
         """
-        This function was intended as an internal method - it just takes the query 
-        you pass it and sends it to the API along with your API ID & Key. If you 
+        This function was intended as an internal method - it just takes the query
+        you pass it and sends it to the API along with your API ID & Key. If you
         know the API or rest real well have at it.
 
         """
@@ -337,20 +335,20 @@ class CSIntelAPI:
         if not self.custid or not self.custkey:
             raise Exception('Customer ID and Customer Key are required')
 
-        fullQuery = self.host + query #host part doesn't change
+        fullQuery = self.host + query   # host part doesn't change
 
         if self.debug:
             print("fullQuery: " + fullQuery)
 
-        headers = self.getHeaders() #format the API key & ID
-        
-        #check for proxy information 
+        headers = self.getHeaders()     # format the API key & ID
+
+        # check for proxy information
         proxies = urllib.getproxies()
 
-        #use requests library to pull request
-        r = requests.get( fullQuery, headers=headers, proxies=proxies ) 
+        # use requests library to pull request
+        r = requests.get(fullQuery, headers=headers, proxies=proxies)
 
-        #Error handling for HTTP request
+        # Error handling for HTTP request
 
         # 400 - bad request
         if r.status_code == 400:
@@ -362,11 +360,10 @@ class CSIntelAPI:
 
         # catch all?
         if r.status_code != 200:
-            raise Exception('HTTP Error: ' + str(r.status_code) )
+            raise Exception('HTTP Error: ' + str(r.status_code))
 
         return r
-    #end request()
-
+    # end request()
 
     def getURLParams(self, **kwargs):
         """
@@ -374,56 +371,56 @@ class CSIntelAPI:
         encodes them all in a single URL string.
         """
 
-        query = urlencode(kwargs) 
+        query = urlencode(kwargs)
         return query
 
     def getActorQuery(self, actor, searchFilter="equal", **kwargs):
         """
-        A specific API query - provide an actor name to retrieve data 
-        on that actor from the intel API. 
+        A specific API query - provide an actor name to retrieve data
+        on that actor from the intel API.
         First optional argument is "searchFilter" which defaults to
         "equal" for an exact match (e.g. Putter Panda) but you can use
-        searchFilter="match" instead to search for a pattern (e.g. 
+        searchFilter="match" instead to search for a pattern (e.g.
         panda).
         Any other keywords passed to the function will be encoded in the
         URL request - in case you want to filter or sort, for example.
         """
-        
+
         valid = ["match", "equal"]
         if searchFilter not in valid:
             raise Exception("not a valid search filter: " + searchFilter)
-        
+
         encodedargs = ""
-        
+
         if any(kwargs):
             encodedargs = "&" + self.getURLParams(**kwargs)
-        
+
         query = "actor?" + searchFilter + "=" + actor + encodedargs
 
         return query
-    #end getActorQuery
+    # end getActorQuery
 
     def SearchActorEqual(self, actor, **kwargs):
-        """ 
-        A specific use of getActorQuery() to match a specific actor and 
+        """
+        A specific use of getActorQuery() to match a specific actor and
         perform the search and return the results found.
-        Any other keywords passed to the function will be encoded in the 
+        Any other keywords passed to the function will be encoded in the
         URL request - in case you want to filter or sort, for example.
         """
         query = self.getActorQuery(actor, perPage=self.perpage, page=self.page, **kwargs)
         result = self.request(query)
         return result
+
     def SearchActorMatch(self, actor, **kwargs):
-        """ 
+        """
         A specific use of getActorQuery() to match actors matching a pattern.
         The API will be queried and will return the results found.
-        Any other keywords passed to the function will be encoded in the 
+        Any other keywords passed to the function will be encoded in the
         URL request - in case you want to filter or sort, for example.
         """
-        query = self.getActorQuery(actor, searchFilter="match", perPage=self.perpage, page=self.page,  **kwargs)
+        query = self.getActorQuery(actor, searchFilter="match", perPage=self.perpage, page=self.page, **kwargs)
         result = self.request(query)
         return result
-
 
     def getIndicatorQuery(self, indicator, searchFilter="equal", **kwargs):
         """
@@ -435,13 +432,13 @@ class CSIntelAPI:
         encodedargs = ""
 
         if any(kwargs):
-            #extra keyword arguments get passed - use to sort, filter.
-            encodedargs = "&" + self.getURLParams(**kwargs) 
+            # extra keyword arguments get passed - use to sort, filter.
+            encodedargs = "&" + self.getURLParams(**kwargs)
 
         query = "indicator?" + searchFilter + "=" + indicator + encodedargs
 
         return query
-    #end getIndicatorQuery
+    # end getIndicatorQuery
 
     def SearchIndicatorEqual(self, indicator, **kwargs):
         """
@@ -449,13 +446,13 @@ class CSIntelAPI:
         Any other keyword arguments passed here will be encoded in the URL
         """
 
-        #build URL query 
-        query = self.getIndicatorQuery(indicator, perPage=self.perpage,  **kwargs)
-        #search API
+        # build URL query
+        query = self.getIndicatorQuery(indicator, perPage=self.perpage, **kwargs)
+        # search API
         result = self.request(query)
-        #return results
+        # return results
         return result
-    #end SearchIndicatorEqual()
+    # end SearchIndicatorEqual()
 
     def SearchIndicatorMatch(self, indicator, **kwargs):
         """
@@ -465,8 +462,8 @@ class CSIntelAPI:
         query = self.getIndicatorQuery(indicator, perPage=self.perpage, page=self.page, **kwargs)
         result = self.request(query)
         return result
-    #end SearchIndicatorMatch()
-    
+    # end SearchIndicatorMatch()
+
     def SearchIP(self, ip):
         """
         Search the API for an IP address
@@ -475,52 +472,52 @@ class CSIntelAPI:
         query = self.getIndicatorQuery(ip, searchFilter="match", type='ip_address', perPage=self.perpage)
         result = self.request(query)
         return result
-    #end SearchIP()
+    # end SearchIP()
 
     def SearchDomain(self, domain):
         """
         Search the API for a domain
         """
 
-        query = self.getIndicatorQuery(domain, searchFilter="match", type='domain', perPage = self.perpage)
+        query = self.getIndicatorQuery(domain, searchFilter="match", type='domain', perPage=self.perpage)
         result = self.request(query)
         return result
-    #end SearchDomain()
+    # end SearchDomain()
 
     def SearchMutex(self, mutex):
         """
         Search the API for a Mutex name
         """
-        
+
         query = self.getIndicatorQuery(mutex, searchFilter="match", type='mutex_name', perPage=self.perpage)
         result = self.request(query)
         return result
-    #end SearchMutex() 
+    # end SearchMutex()
 
     def SearchHash(self, myhash):
         """
-        Search the API for a file hash. 
+        Search the API for a file hash.
         The function will use the length of the hash string to limit the API
         query to a specific type of hash (i.e. MD5, SHA-1, SHA-256.
         """
 
-        #get length of hash and figure out what type it is
-        l = len(myhash)
-        if l == 32:
+        # get length of hash and figure out what type it is
+        hash_len = len(myhash)
+        if hash_len == 32:
             htype = 'hash_md5'
-        elif l == 40:
+        elif hash_len == 40:
             htype = 'hash_sha1'
-        elif l == 64:
+        elif hash_len == 64:
             htype = 'hash_sha256'
         else:
             raise Exception("You sure that hash was right?")
 
-        #build query to search for hash by type
+        # build query to search for hash by type
         query = self.getIndicatorQuery(myhash, type=htype, perPage=self.perpage)
-        #search API 
+        # search API
         result = self.request(query)
         return result
-    #end SearchHash()
+    # end SearchHash()
 
     def getLastUpdatedQuery(self, date, searchFilter, **kwargs):
         """
@@ -531,8 +528,8 @@ class CSIntelAPI:
         encodedargs = ""
 
         if any(kwargs):
-            #extra keyword arguments get passed - use to sort, filter.
-            encodedargs = self.getURLParams(**kwargs)  
+            # extra keyword arguments get passed - use to sort, filter.
+            encodedargs = self.getURLParams(**kwargs)
 
         query = "last_updated?" + searchFilter + "=" + str(date) + "&" + encodedargs
 
@@ -540,14 +537,14 @@ class CSIntelAPI:
             print("query: " + query)
 
         return query
-    #end getLastUpdatedQuery
+    # end getLastUpdatedQuery
 
     def SearchLastUpdated(self, date, searchFilter="gte", **kwargs):
         """
         Get API updates before or after the date specified and return the results
         Extra keyword arguments are passed so you can sort, etc.
         """
-        
+
         if searchFilter not in self.validFilter:
             raise Exception("Invalid search filter for last_updated")
 
@@ -556,23 +553,23 @@ class CSIntelAPI:
         result = self.request(query)
 
         return result
-    #end SearchDate()
+    # end SearchDate()
 
     def getEpochDaysAgo(self, days):
         """
         Pass this function an interger n and this function will return
         the epoc time for n days ago.
-        getEpochDaysAgo(1), for example, returns the epoch time for 
+        getEpochDaysAgo(1), for example, returns the epoch time for
         yesterday (24 hours ago).
         """
 
-        #get datetime object for n days ago.
+        # get datetime object for n days ago.
         daysago = datetime.now() - timedelta(days=days)
 
-        #convert that to standard unix time, ust int() to chop off decimal.
-        etime = int((daysago - datetime(1970,1,1)).total_seconds())
+        # convert that to standard unix time, ust int() to chop off decimal.
+        etime = int((daysago - datetime(1970, 1, 1)).total_seconds())
 
-        #return number of seconds
+        # return number of seconds
         return etime
 
     def SearchLastDay(self, **kwargs):
@@ -585,8 +582,8 @@ class CSIntelAPI:
         result = self.SearchLastUpdated(etime, **kwargs)
 
         return result
-    #end SearchLastDay()
-   
+    # end SearchLastDay()
+
     def SearchLastWeek(self, **kwargs):
         """
         Pull any Intel data that has been updated in the last week.
@@ -597,30 +594,29 @@ class CSIntelAPI:
         result = self.SearchLastUpdated(etime, **kwargs)
 
         return result
-    #end SearchLastWeek()
+    # end SearchLastWeek()
 
-    
     def GetReportQuery(self, report, searchFilter, **kwargs):
         """
         Build an API query to search by report name.
-        Must pass it a report name as a string. 
+        Must pass it a report name as a string.
         I assume searchFilter is equal OR match but come to think of it I've
         only tested "equal."
-        Other keyword arguments can be passed to include sorting etc. 
+        Other keyword arguments can be passed to include sorting etc.
         Returns a string for the URL query search.
         """
-        #TODO - match reports?? 
+        # TODO - match reports??
         encodedargs = ""
 
         if any(kwargs):
-            #extra keyword arguments get passed - use to sort, filter.
-            encodedargs = "&" + self.getURLParams(**kwargs)  
+            # extra keyword arguments get passed - use to sort, filter.
+            encodedargs = "&" + self.getURLParams(**kwargs)
 
-        #build the query string
+        # build the query string
         query = "report?" + searchFilter + "=" + report + encodedargs
 
         return query
-    #end GetReportQuery()
+    # end GetReportQuery()
 
     def SearchReport(self, report, searchFilter="equal", **kwargs):
         """
@@ -632,8 +628,7 @@ class CSIntelAPI:
         result = self.request(query)
 
         return result
-    #end SearchReport()
-
+    # end SearchReport()
 
     def SearchTarget(self, target, searchFilter="match", **kwargs):
         """
@@ -642,23 +637,22 @@ class CSIntelAPI:
         Returns the results of the API query.
         """
 
-        #validate target
+        # validate target
         validTarget = ['Aerospace', 'Agricultural', 'Chemical', 'Defense', 'Dissident', 'Energy', 'Extractive', 'Financial', 'Government', 'Healthcare', 'Insurance', 'International Organizations', 'Legal', 'Manufacturing', 'Media', 'NGO', 'Pharmaceutical', 'Research', 'Retail', 'Shipping', 'Technology', 'Telecom', 'Transportation', 'Universities']
         if searchFilter not in self.validFilter:
             raise Exception("Invalid search filter")
         if target not in validTarget:
             raise Exception("Invalid target industry")
 
-        #append industry
+        # append industry
         label = "Target/" + target
 
         query = self.GetLabelQuery(label, searchFilter, perPage=self.perpage, page=self.page, **kwargs)
         result = self.request(query)
 
         return result
-    #end SearchTarget()
+    # end SearchTarget()
 
-    
     def GetLabelQuery(self, label, searchFilter, **kwargs):
         """
         Build an API query to serach by Label.
@@ -671,26 +665,26 @@ class CSIntelAPI:
         Returns a string for the URL query search
         """
 
-        #good query: search/labels?match=Retail
+        # good query: search/labels?match=Retail
 
         encodedargs = ""
 
         if any(kwargs):
-            #extra keyword arguments get passed - used to sort, filter.
+            # extra keyword arguments get passed - used to sort, filter.
             encodedargs = "&" + self.getURLParams(**kwargs)
 
-        #build the query string
+        # build the query string
         query = "labels?" + searchFilter + "=" + label + encodedargs
 
         return query
-    #end GetLabelQuery
-    
+    # end GetLabelQuery
+
     def SearchLabel(self, label, searchFilter="match", **kwargs):
         """
         Search the API for a specific Label
         Pass the label as a string, and any other options.
         Returns the results of the API query.
-        
+
         Labels are a generic framework for attaching metadata to an intel
         indicator. See the documentation for full capabilities or checkout
         the functions that call this one.
@@ -699,8 +693,8 @@ class CSIntelAPI:
         For example, MaliciousConfidence/High
 
         """
- 
-        #validate 
+
+        # validate
         if searchFilter not in self.validFilter:
             raise Exception("Invalid search filter")
 
@@ -708,82 +702,78 @@ class CSIntelAPI:
         result = self.request(query)
 
         return result
-    #end SearchLabel()
-   
+    # end SearchLabel()
 
     def SearchConfidence(self, confidence, searchFilter="match", **kwargs):
         """
         Search the API by Malicious Confidence.
-        Pass the level (high, medium, low, unverified) as a string, 
+        Pass the level (high, medium, low, unverified) as a string,
         and any other options.
         Returns the results of the API query.
         """
 
-        #validate target
+        # validate target
         validConfidence = ['high', 'medium', 'low', 'unverified']
         if searchFilter not in self.validFilter:
             raise Exception("Invalid search filter")
         if confidence not in validConfidence:
             raise Exception("Invalid confidence level: " + confidence)
 
-        #append industry
+        # append industry
         label = "MaliciousConfidence/" + confidence
 
         query = self.GetLabelQuery(label, searchFilter, perPage=self.perpage, page=self.page, **kwargs)
         result = self.request(query)
 
         return result
-    #end SearchConfidence()
-
+    # end SearchConfidence()
 
     def SearchKillChain(self, chain, searchFilter="match", **kwargs):
         """
         Search the API by Kill Chain stage.
-        Pass the level as a string, 
+        Pass the level as a string,
         and any other options.
         Returns the results of the API query.
         """
 
-        #validate parameters
+        # validate parameters
         validKillChain = ['reconnaissance', 'weaponization', 'delivery', 'exploitation', 'installation', 'c2', 'actionsonobjectives']
         if searchFilter not in self.validFilter:
             raise Exception("Invalid search filter")
         if chain not in validKillChain:
             raise Exception("Invalid kill chain link: " + chain)
 
-        #append chain to label type
+        # append chain to label type
         label = "kill_chain/" + chain
 
         query = self.GetLabelQuery(label, searchFilter, perPage=self.perpage, page=self.page, **kwargs)
         result = self.request(query)
 
         return result
-    #end SearchKillChain()
-
+    # end SearchKillChain()
 
     def SearchMalware(self, malware, searchFilter="match", **kwargs):
         """
         Search the API by malware family.
-        Pass the level as a string, 
+        Pass the level as a string,
         and any other options.
         Returns the results of the API query.
         """
 
-        #validate parameters
+        # validate parameters
         if searchFilter not in self.validFilter:
             raise Exception("Invalid search filter")
-       
+
         encodedargs = ""
         if any(kwargs):
             encodedargs = "&" + self.getURLParams(**kwargs)
-        
+
         query = "malware_family?" + searchFilter + "=" + malware + encodedargs
 
         result = self.request(query)
 
         return result
-    #end SearchMalware()
-
+    # end SearchMalware()
 
     def SearchActive(self, searchFilter="match", **kwargs):
         """
@@ -793,104 +783,100 @@ class CSIntelAPI:
         Returns the results of the API query.
         """
 
-        #validate parameters
+        # validate parameters
         if searchFilter not in self.validFilter:
             raise Exception("Invalid search filter")
 
-        #append chain to label type
+        # append chain to label type
         label = "confirmedactive"
 
         query = self.GetLabelQuery(label, searchFilter, perPage=self.perpage, page=self.page, **kwargs)
         result = self.request(query)
 
         return result
-    #end SearchActive()
-
+    # end SearchActive()
 
     def SearchThreatType(self, threat, searchFilter="match", **kwargs):
         """
         Search the API by threat type
-        Pass the level as a string, 
+        Pass the level as a string,
         and any other options.
         Returns the results of the API query.
         """
 
-        #validate parameters
+        # validate parameters
         validThreat = ['ClickFraud', 'Commodity', 'PointOfSale', 'Ransomware', 'Suspicious', 'Targeted', 'TargetedCrimeware', 'Vulnerability']
         if searchFilter not in self.validFilter:
             raise Exception("Invalid search filter")
         if threat not in validThreat:
             raise Exception("Invalid Threat type: " + threat)
 
-        #append chain to label type
+        # append chain to label type
         label = "ThreatType/" + threat
 
         query = self.GetLabelQuery(label, searchFilter, **kwargs)
         result = self.request(query)
 
         return result
-    #end SearchThreatType()
-
+    # end SearchThreatType()
 
     def SearchDomainType(self, domain, searchFilter="match", **kwargs):
         """
         Search the API by domain type
-        Pass the level as a string, 
+        Pass the level as a string,
         and any other options.
         Returns the results of the API query.
         """
 
-        #validate parameters
+        # validate parameters
         validType = ['ActorControlled', 'DGA', 'DynamicDNS', 'DynamicDNS/Afraid', 'DynamicDNS/DYN', 'DynamicDNS/Hostinger', 'DynamicDNS/noIP', 'DynamicDNS/Oray', 'KnownGood', 'LegitimateCompromised', 'PhishingDomain', 'Sinkholed', 'StrategicWebCompromise', 'Unregistered']
         if searchFilter not in self.validFilter:
             raise Exception("Invalid search filter")
         if domain not in validType:
             raise Exception("Invalid Domain type: " + domain)
 
-        #append chain to label type
+        # append chain to label type
         label = "DomaintType/" + domain
 
         query = self.GetLabelQuery(label, searchFilter, perPage=self.perpage, page=self.page, **kwargs)
         result = self.request(query)
 
         return result
-    #end SearchDomainType()
-
+    # end SearchDomainType()
 
     def SearchEmailType(self, email, searchFilter="match", **kwargs):
         """
         Search the API by email address type
-        Pass the email address type as a string, 
+        Pass the email address type as a string,
         and any other options.
         Returns the results of the API query.
         """
 
-        #validate parameters
+        # validate parameters
         validType = ['DomainRegistrant', 'SpearphishSender']
         if searchFilter not in self.validFilter:
             raise Exception("Invalid search filter")
         if email not in validType:
-            raise Exception("Invalid Domain type: " + domain)
+            raise Exception("Invalid email type: " + email)
 
-        #append chain to label type
+        # append chain to label type
         label = "EmailAddressType/" + email
 
         query = self.GetLabelQuery(label, searchFilter, perPage=self.perpage, page=self.page, **kwargs)
         result = self.request(query)
 
         return result
-    #end SearchEmailType()
-
+    # end SearchEmailType()
 
     def SearchIPType(self, iptype, searchFilter="match", **kwargs):
         """
         Search the API by ip address type
-        Pass the ip address type as a string, 
+        Pass the ip address type as a string,
         and any other options.
         Returns the results of the API query.
         """
 
-        #validate parameters
+        # validate parameters
         validType = ['HtranDestinationNode', 'HtranProxy', 'HtranProxy', 'LegitimateCompromised', 'Parking', 'PopularSite', 'SharedWebHost', 'Sinkholed', 'TorProxy']
         if searchFilter not in self.validFilter:
             raise Exception("Invalid search filter")
@@ -903,15 +889,11 @@ class CSIntelAPI:
         result = self.request(query)
 
         return result
-    #end SearchIPType()
+    # end SearchIPType()
 
-
-
-
-
-#===================================
+# ===================================
 # Output
-#===================================
+# ===================================
 
     def GetHashesFromResults(self, result, related=False):
         """
@@ -923,29 +905,29 @@ class CSIntelAPI:
         """
 
         hashes = []
-        #loop through json
+        # loop through json
         for item in result:
             itype = item['type']
             if itype.find("hash") >= 0:
-                #If the indicator is a hash, add it do the list
-                hashes.append( item['indicator'] )
+                # If the indicator is a hash, add it do the list
+                hashes.append(item['indicator'])
             if related:
-                #are we doing related indicators too?
+                # are we doing related indicators too?
                 for relation in item['relations']:
                     itype = relation['type']
                     if itype.find("hash") >= 0:
-                        #if it's a hash, add it to the list.
-                        hashes.append( relation['indicator'] )
+                        # if it's a hash, add it to the list.
+                        hashes.append(relation['indicator'])
 
-        #return list of hashes
+        # return list of hashes
         return hashes
-    #end GetHashesFromResults()
+    # end GetHashesFromResults()
 
     def GetIndicatorsFromResults(self, result, labels=True, related=False):
         """
         Give this function results from an API query and it will pull out
         all of the indicators and return them as a list.
-        The labels option will include all the label strings tied to that 
+        The labels option will include all the label strings tied to that
         indicator. Each label will be added to the same line but deliminated
         with a colon. This is enabled by default.
         This funciton is intended to be much more verbose with its indicators than
@@ -958,32 +940,32 @@ class CSIntelAPI:
 
         indicators = []
         for item in result:
-            #loop through each JSON object
+            # loop through each JSON object
             la = ":"
-            #format: type:indicator:(labels)
+            # format: type:indicator:(labels)
             x = item['type'] + ":" + item['indicator']
             if labels:
-                #if labels are included then grab them and add them
-                #to the string we're building here.
+                # if labels are included then grab them and add them
+                # to the string we're building here.
                 for label in item['labels']:
-                    #loop through each label and add it.
+                    # loop through each label and add it.
                     la += label['name']
-                    la += ":" #deliminator
+                    la += ":"  # deliminator
 
             if related:
-                #are we including related indicators?
+                # are we including related indicators?
                 for relation in item['relations']:
-                    #loop through each item in relations
+                    # loop through each item in relations
                     y = relation['type'] + ":" + relation['indicator'] + ":related"
-                    #add it to the list
+                    # add it to the list
                     indicators.append(y)
-            x += la #add labels
-            #add to list
+            x += la  # add labels
+            # add to list
             indicators.append(x)
 
-        #return list of strings
+        # return list of strings
         return indicators
-    #end GetIndicatorFromResults()
+    # end GetIndicatorFromResults()
 
     def GetReportsFromResults(self, result):
         """
@@ -996,18 +978,18 @@ class CSIntelAPI:
 
         reports = []
         for item in result:
-            #loop through each JSON indicator
+            # loop through each JSON indicator
             r = item['reports']
-            #does it have anything in the reports section?
+            # does it have anything in the reports section?
             if r:
                 for x in r:
-                    #if it exists, add each item in the list of reports
-                    #to our list
+                    # if it exists, add each item in the list of reports
+                    # to our list
                     reports.append(x)
 
-        #return list of strings of reports
+        # return list of strings of reports
         return reports
-    #end GetReportsFromResults()
+    # end GetReportsFromResults()
 
     def GetDomainsFromResults(self, result, related=False):
         """
@@ -1020,23 +1002,23 @@ class CSIntelAPI:
         """
 
         domains = []
-        #loop through each JSON object
+        # loop through each JSON object
         for item in result:
-            #check each indicator to see if the type is domain
+            # check each indicator to see if the type is domain
             if item['type'] == "domain":
-                #add domains to the list
-                domains.append( item['indicator'] )
+                # add domains to the list
+                domains.append(item['indicator'])
 
             if related:
-                #should we include related indicators? 
+                # should we include related indicators?
                 for relation in item['relations']:
                     if relation['type'] == "domain":
-                        #if it's a domain, add it to the list.
-                        domains.append( relation['indicator'] )
+                        # if it's a domain, add it to the list.
+                        domains.append(relation['indicator'])
 
-        #return a list of strings of domains
+        # return a list of strings of domains
         return domains
-    #end GetDomainsFromResults()
+    # end GetDomainsFromResults()
 
     def GetIPsFromResults(self, result, related=False):
         """
@@ -1049,24 +1031,24 @@ class CSIntelAPI:
         """
 
         ips = []
-        #loop through each JSON indicator
+        # loop through each JSON indicator
         for item in result:
-            #pick ou the indicators that are IPs
+            # pick ou the indicators that are IPs
             if item['type'] == "ip_address":
-                #and add them to the list
-                ips.append( item['indicator'] )
+                # and add them to the list
+                ips.append(item['indicator'])
 
             if related:
-                #If you also wanted related indicators, loop through
-                #those and check for IP addresses as well.
+                # If you also wanted related indicators, loop through
+                # those and check for IP addresses as well.
                 for relation in item['relations']:
                     if relation['type'] == "ip_address":
-                        #find the IPs and add them to the list.
-                        ips.append( relation['indicator'] )
+                        # find the IPs and add them to the list.
+                        ips.append(relation['indicator'])
 
-        #return list of strings of IP addresses
+        # return list of strings of IP addresses
         return ips
-    #end GetIPsFromResults()
+    # end GetIPsFromResults()
 
     def GetActorsFromResults(self, result):
         """
@@ -1078,26 +1060,23 @@ class CSIntelAPI:
         """
 
         actors = []
-        #loop through each JSON item in the results
+        # loop through each JSON item in the results
         for item in result:
-            #grab the actors section
+            # grab the actors section
             a = item['actors']
             if a:
-                #if there's anything in here loop through them
+                # if there's anything in here loop through them
                 for x in a:
-                    #add each actor the list we're building
+                    # add each actor the list we're building
                     actors.append(x)
 
-        #return the list of actors that have been identified.
-        #This list is raw, you may want to sort and dedupe.
+        # return the list of actors that have been identified.
+        # This list is raw, you may want to sort and dedupe.
         return actors
-    #end GetActorsFromResults()
+    # end GetActorsFromResults()
 
 
-
-
-
-"""   REFERENCE 
+"""   REFERENCE
 example = "actor?equal=ROCKETKITTEN"
 example = "indicator?equal=www.we11point.com"
 example = "actor?match=panda"
@@ -1105,10 +1084,10 @@ example = "actor?match=panda&sort=malicious_confidence&order=desc"
 example = "last_updated?gte=1427846400&sort=last_updated&order=asc&perPage=100&page=1"
 """
 
-#end class CSIntelAPI
+# end class CSIntelAPI
 ######################################################################################
 
-""" 
+"""
 This section sets up the module to use not as a class but called directly from the CLI
 """
 
@@ -1120,7 +1099,7 @@ if __name__ == "__main__":
     never runs if this file was imported.
 
     To see how this file can be executed directly run it with "-h" to see the
-    help on which command line flags are needed. 
+    help on which command line flags are needed.
 
     The primary requirement is to feed this scrip your Customer ID and Key. This
     can be done through CLI arguments or by specificying a config file. See the
@@ -1128,190 +1107,189 @@ if __name__ == "__main__":
 
     There are output options to select as well, with --out. The default, all, is to
     print all the json received. You can also select to print out all the
-    indicators, which will show each prepended by the type of indicator. 
+    indicators, which will show each prepended by the type of indicator.
     """
     import argparse
     import json
     import pprint
 
-    #Let's set this up to parse setup config and other arguments from the CLI
-    parser = argparse.ArgumentParser( description="CS Intel API - This program can be executed directly to work with CrowdStrike's Threat Intel API or be imported into other scripts to use.")
-    parser.add_argument( '--custid', type=str, help="API Customer ID", default=None)
-    parser.add_argument( '--custkey', type=str, help="API Customer Key", default=None)
-    parser.add_argument( '--perPage', '-p', type=str, help="How many indicators per page?", default = "100") 
-    parser.add_argument( '--Page', type=str, help="Page number of results to get.", default = "1") 
-    parser.add_argument( '--write', '-w', action='store_true', default=False, help='Write the API config to the file specified by the --config option')
-    parser.add_argument( '--config', '-c', type=str, help="Configuration File Name", default=defaultConfigFileName)
-    parser.add_argument( '--raw', action='store_true', default=False, help='Raw JSON, do not print pretty')
-    parser.add_argument( '--debug', '-b', action='store_true', default=False, help='Turn on some debug strings')
+    # Let's set this up to parse setup config and other arguments from the CLI
+    parser = argparse.ArgumentParser(description="CS Intel API - This program can be executed directly to work with CrowdStrike's Threat Intel API or be imported into other scripts to use.")
+    parser.add_argument('--custid', type=str, help="API Customer ID", default=None)
+    parser.add_argument('--custkey', type=str, help="API Customer Key", default=None)
+    parser.add_argument('--perPage', '-p', type=str, help="How many indicators per page?", default="100")
+    parser.add_argument('--Page', type=str, help="Page number of results to get.", default="1")
+    parser.add_argument('--write', '-w', action='store_true', default=False, help='Write the API config to the file specified by the --config option')
+    parser.add_argument('--config', '-c', type=str, help="Configuration File Name", default=defaultConfigFileName)
+    parser.add_argument('--raw', action='store_true', default=False, help='Raw JSON, do not print pretty')
+    parser.add_argument('--debug', '-b', action='store_true', default=False, help='Turn on some debug strings')
 
-    #Error management is easier by specificying a group for the commands that can be used.
-    #Each of these are actions/searches the script can take.
+    # Error management is easier by specificying a group for the commands that can be used.
+    # Each of these are actions/searches the script can take.
     cmdGroup = parser.add_mutually_exclusive_group(required=True)
-    cmdGroup.add_argument( '--actor', '-a', type=str, help="Search for an actor by name", default=None)
-    cmdGroup.add_argument( '--actors', '-s', type=str, help="Search for a actors by pattern", default=None)
-    cmdGroup.add_argument( '--ip', type=str, help="Search for an IP address", default=None)
-    cmdGroup.add_argument( '--domain', type=str, help="Search for a domain", default=None)
-    cmdGroup.add_argument( '--report', type=str, help="Search for a report name, e.g. CSIT-XXXX", default=None)
-    cmdGroup.add_argument( '--indicator', '-i', type=str, help="Search for an indicator", default=None)
-    cmdGroup.add_argument( '--label', '-l', type=str, help="Search for a label", default=None)
-    cmdGroup.add_argument( '--target', type=str, help="Search by Targeted Industry", default=None)
-    cmdGroup.add_argument( '--confidence', type=str, help="Search by Malicious Confidence", default=None)
-    cmdGroup.add_argument( '--killchain', type=str, help="Search by kill chain stage", default=None)
-    cmdGroup.add_argument( '--malware', type=str, help="Search by malware family", default=None)
-    cmdGroup.add_argument( '--active', action='store_true', help="Get confirmed active indicators", default=None)
-    cmdGroup.add_argument( '--threat', type=str, help="Search by threat type", default=None)
-    cmdGroup.add_argument( '--domaintype', type=str, help="Search by domain type", default=None)
-    cmdGroup.add_argument( '--iptype', type=str, help="Search by IP Type", default=None)
-    cmdGroup.add_argument( '--emailtype', type=str, help="Search by email address type", default=None)
-    cmdGroup.add_argument( '--day', action='store_true', help="Get all indicators that have changed in 24 hours", default=None)
-    cmdGroup.add_argument( '--week', action='store_true', help="Get all indicators that have changed in the past week", default=None)
+    cmdGroup.add_argument('--actor', '-a', type=str, help="Search for an actor by name", default=None)
+    cmdGroup.add_argument('--actors', '-s', type=str, help="Search for a actors by pattern", default=None)
+    cmdGroup.add_argument('--ip', type=str, help="Search for an IP address", default=None)
+    cmdGroup.add_argument('--domain', type=str, help="Search for a domain", default=None)
+    cmdGroup.add_argument('--report', type=str, help="Search for a report name, e.g. CSIT-XXXX", default=None)
+    cmdGroup.add_argument('--indicator', '-i', type=str, help="Search for an indicator", default=None)
+    cmdGroup.add_argument('--label', '-l', type=str, help="Search for a label", default=None)
+    cmdGroup.add_argument('--target', type=str, help="Search by Targeted Industry", default=None)
+    cmdGroup.add_argument('--confidence', type=str, help="Search by Malicious Confidence", default=None)
+    cmdGroup.add_argument('--killchain', type=str, help="Search by kill chain stage", default=None)
+    cmdGroup.add_argument('--malware', type=str, help="Search by malware family", default=None)
+    cmdGroup.add_argument('--active', action='store_true', help="Get confirmed active indicators", default=None)
+    cmdGroup.add_argument('--threat', type=str, help="Search by threat type", default=None)
+    cmdGroup.add_argument('--domaintype', type=str, help="Search by domain type", default=None)
+    cmdGroup.add_argument('--iptype', type=str, help="Search by IP Type", default=None)
+    cmdGroup.add_argument('--emailtype', type=str, help="Search by email address type", default=None)
+    cmdGroup.add_argument('--day', action='store_true', help="Get all indicators that have changed in 24 hours", default=None)
+    cmdGroup.add_argument('--week', action='store_true', help="Get all indicators that have changed in the past week", default=None)
 
-    parser.add_argument( '--out', '-o', choices=['all', 'indicators', 'hashes', 'domains', 'ips', 'actors', 'reports', 'IfReport'], help="What should I print? Default: all", default='all')
-    parser.add_argument( '--related', action='store_true', help="Flag: Include related indicators.", default=False)
-   
-    #run this and parse out the arguments
+    parser.add_argument('--out', '-o', choices=['all', 'indicators', 'hashes', 'domains', 'ips', 'actors', 'reports', 'IfReport'], help="What should I print? Default: all", default='all')
+    parser.add_argument('--related', action='store_true', help="Flag: Include related indicators.", default=False)
+
+    # run this and parse out the arguments
     args = parser.parse_args()
 
-    #Some error checking on parsed configuration
-    if args.write == True and args.config == None:
+    # Some error checking on parsed configuration
+    if args.write is True and args.config is None:
         raise Exception("To write to config file you must pass file name to --config")
-    if (args.custid == None and args.custkey is not None) or  (args.custkey == None and args.custid is not None):
+    if (args.custid is None and args.custkey is not None) or (args.custkey is None and args.custid is not None):
         raise Exception("Must include both customer ID and key")
 
-
-    #Now check to see if we're getting API settings from CLI or config file
-    #if the write flag is set pass the config file name to be written to.
-    if args.custid is not None: 
-        #use CLI parameters
+    # Now check to see if we're getting API settings from CLI or config file
+    # if the write flag is set pass the config file name to be written to.
+    if args.custid is not None:
+        # use CLI parameters
         custid = args.custid
         custkey = args.custkey
-    else: 
+    else:
         # no ID and key from argument, get them from config file
-        (custid, custkey, perpage) = readConfig( args.config )
+        (custid, custkey, perpage) = readConfig(args.config)
 
-    #Create the API object 
+    # Create the API object
     api_obj = CSIntelAPI(custid, custkey, args.perPage, args.Page, args.debug)
 
     # Check to see if config in memory should be written to disk
     if args.write:
-        api_obj.writeConfig( args.config )
+        api_obj.writeConfig(args.config)
 
-    #now do stuff...
+    # now do stuff...
 
-    if args.actors is not None: #search actors for a pattern
-        result = api_obj.SearchActorMatch( args.actors , sort='actor')
+    if args.actors is not None:         # search actors for a pattern
+        result = api_obj.SearchActorMatch(args.actors, sort='actor')
 
-    if args.actor is not None: #search actors for a specific actor
-        result = api_obj.SearchActorEqual( args.actor , sort="malicious_confidence", order='desc' )
+    if args.actor is not None:          # search actors for a specific actor
+        result = api_obj.SearchActorEqual(args.actor, sort="malicious_confidence", order='desc')
 
-    if args.ip is not None: #search API for an IP address
-        result = api_obj.SearchIP( args.ip )
+    if args.ip is not None:             # search API for an IP address
+        result = api_obj.SearchIP(args.ip)
 
-    if args.domain is not None: #search API for a domain
-        result = api_obj.SearchDomain( args.domain )
+    if args.domain is not None:         # search API for a domain
+        result = api_obj.SearchDomain(args.domain)
 
-    if args.report is not None: #search API for a report name
-        result = api_obj.SearchReport( args.report )
-        
-    if args.indicator is not None: #generic indicator search
-        result = api_obj.SearchIndicatorMatch( args.indicator )
+    if args.report is not None:         # search API for a report name
+        result = api_obj.SearchReport(args.report)
 
-    if args.label is not None: # generic label search
-        result = api_obj.SearchLabel( args.label )
+    if args.indicator is not None:      # generic indicator search
+        result = api_obj.SearchIndicatorMatch(args.indicator)
 
-    if args.target is not None: #search targeted industry
-        result = api_obj.SearchTarget( args.target )
+    if args.label is not None:          # generic label search
+        result = api_obj.SearchLabel(args.label)
 
-    if args.confidence is not None: #search malicious confidence
-        result = api_obj.SearchConfidence( args.confidence )
+    if args.target is not None:         # search targeted industry
+        result = api_obj.SearchTarget(args.target)
 
-    if args.killchain is not None: #search by kill chain stage
-        result = api_obj.SearchKillChain( args.killchain )
+    if args.confidence is not None:     # search malicious confidence
+        result = api_obj.SearchConfidence(args.confidence)
 
-    if args.malware is not None: #search by malware family
-        result = api_obj.SearchMalware( args.malware )
+    if args.killchain is not None:      # search by kill chain stage
+        result = api_obj.SearchKillChain(args.killchain)
 
-    if args.active is not None: #search for confirmed active malware
+    if args.malware is not None:        # search by malware family
+        result = api_obj.SearchMalware(args.malware)
+
+    if args.active is not None:         # search for confirmed active malware
         print("WTF LOL")
         result = api_obj.SearchActive()
 
-    if args.threat is not None: #search by threat type
-        result = api_obj.SearchThreatType( args.threat )
+    if args.threat is not None:         # search by threat type
+        result = api_obj.SearchThreatType(args.threat)
 
-    if args.domaintype is not None: #search by domain type
-        result = api_obj.SearchDomainType( args.domaintype )
+    if args.domaintype is not None:     # search by domain type
+        result = api_obj.SearchDomainType(args.domaintype)
 
-    if args.iptype is not None: #search by IP Address type
-        result = api_obj.SearchIPType( args.iptype )
+    if args.iptype is not None:         # search by IP Address type
+        result = api_obj.SearchIPType(args.iptype)
 
-    if args.emailtype is not None: #search by email type
-        result = api_obj.SearchEmailType( args.emailtype )
+    if args.emailtype is not None:      # search by email type
+        result = api_obj.SearchEmailType(args.emailtype)
 
-    if args.day is not None: #grab indicators for the last day
+    if args.day is not None:            # grab indicators for the last day
         result = api_obj.SearchLastDay()
 
-    if args.week is not None: #grab indicators for the last week
+    if args.week is not None:           # grab indicators for the last week
         result = api_obj.SearchLastWeek()
 
-    #load the raw JSON into python friendly structure
-    data = json.loads( result.text )
+    # load the raw JSON into python friendly structure
+    data = json.loads(result.text)
 
-    #print results
+    # print results
     if args.out == "hashes":
-        #get hashes form results, pass related option
+        # get hashes form results, pass related option
         hashes = api_obj.GetHashesFromResults(data, related=args.related)
         for h in hashes:
             print(h)
     elif args.out == "indicators":
-        #get all the indicators
+        # get all the indicators
         indicators = api_obj.GetIndicatorsFromResults(data, related=args.related)
-        #dedupe indicators
+        # dedupe indicators
         uniqueIndicators = set(indicators)
-        #print them one per line
+        # print them one per line
         for i in uniqueIndicators:
             print(i)
     elif args.out == "reports":
-        #print any report names associated with these indicators
+        # print any report names associated with these indicators
         reports = api_obj.GetReportsFromResults(data)
-        reports.sort() #sort list
+        reports.sort()  # sort list
         for r in reports:
-            #print one per line
+            # print one per line
             print(r)
     elif args.out == "domains":
-        #get the domains from our results
+        # get the domains from our results
         domains = api_obj.GetDomainsFromResults(data, related=args.related)
-        domains.sort() #sort list
-        #print one per line
+        domains.sort()  # sort list
+        # print one per line
         for d in domains:
             print(d)
     elif args.out == "actors":
-        #print what actors are tied to these indicators
+        # print what actors are tied to these indicators
         actors = api_obj.GetActorsFromResults(data)
-        #dedupe the list
+        # dedupe the list
         uniqueActors = set(actors)
         for a in uniqueActors:
-            #print one per line
+            # print one per line
             print(a)
     elif args.out == "ips":
-        #get the IP addresses from our list of indicators
+        # get the IP addresses from our list of indicators
         ips = api_obj.GetIPsFromResults(data, related=args.related)
-        uniqueIps = set(ips) #dedupe list
+        uniqueIps = set(ips)  # dedupe list
         for i in uniqueIps:
-            #print one per line
+            # print one per line
             print(i)
     elif args.out == "IfReport":
-        #print out the raw data, but only if there is an associated
-        #report with it.
+        # print out the raw data, but only if there is an associated
+        # report with it.
         for datum in data:
             if len(datum['reports']) > 0:
                 print(datum)
 
     else:
-        #by default pretty print the whole JSON
-        if args.raw == False:
-            pprint.pprint( data )
+        # by default pretty print the whole JSON
+        if args.raw is False:
+            pprint.pprint(data)
         else:
             print(data)
 
-#EOF
+# EOF

--- a/CSIntel.py
+++ b/CSIntel.py
@@ -1,4 +1,4 @@
-#!/usr/local/bin/python
+#!/usr/bin/env python3
 
 """
 This file will act as a Python API for CrowdStrike's Threat Intelligence API. It was built to make it
@@ -153,11 +153,20 @@ written by: adam.hogan@crowdstrike.com
 """
 
 import requests
-from ConfigParser import SafeConfigParser
-from urllib import urlencode
+try:        # python3
+    from configparser import SafeConfigParser
+except Exception:     # python2
+    from ConfigParser import SafeConfigParser
+try:        # python3
+    from urllib.parse import urlencode
+except Exception:
+    from urllib import urlencode
 from datetime import datetime, timedelta
 import os
-import urllib
+try:        # python3
+    import urllib.request as urllib
+except Exception:     # python2
+    import urllib
 
 
 #Global
@@ -331,7 +340,7 @@ class CSIntelAPI:
         fullQuery = self.host + query #host part doesn't change
 
         if self.debug:
-            print "fullQuery: " + fullQuery
+            print("fullQuery: " + fullQuery)
 
         headers = self.getHeaders() #format the API key & ID
         
@@ -528,7 +537,7 @@ class CSIntelAPI:
         query = "last_updated?" + searchFilter + "=" + str(date) + "&" + encodedargs
 
         if self.debug:
-            print "query: " + query
+            print("query: " + query)
 
         return query
     #end getLastUpdatedQuery
@@ -1224,7 +1233,7 @@ if __name__ == "__main__":
         result = api_obj.SearchMalware( args.malware )
 
     if args.active is not None: #search for confirmed active malware
-        print "WTF LOL"
+        print("WTF LOL")
         result = api_obj.SearchActive()
 
     if args.threat is not None: #search by threat type
@@ -1253,7 +1262,7 @@ if __name__ == "__main__":
         #get hashes form results, pass related option
         hashes = api_obj.GetHashesFromResults(data, related=args.related)
         for h in hashes:
-            print h
+            print(h)
     elif args.out == "indicators":
         #get all the indicators
         indicators = api_obj.GetIndicatorsFromResults(data, related=args.related)
@@ -1261,21 +1270,21 @@ if __name__ == "__main__":
         uniqueIndicators = set(indicators)
         #print them one per line
         for i in uniqueIndicators:
-            print i
+            print(i)
     elif args.out == "reports":
         #print any report names associated with these indicators
         reports = api_obj.GetReportsFromResults(data)
         reports.sort() #sort list
         for r in reports:
             #print one per line
-            print r
+            print(r)
     elif args.out == "domains":
         #get the domains from our results
         domains = api_obj.GetDomainsFromResults(data, related=args.related)
         domains.sort() #sort list
         #print one per line
         for d in domains:
-            print d
+            print(d)
     elif args.out == "actors":
         #print what actors are tied to these indicators
         actors = api_obj.GetActorsFromResults(data)
@@ -1283,26 +1292,26 @@ if __name__ == "__main__":
         uniqueActors = set(actors)
         for a in uniqueActors:
             #print one per line
-            print a
+            print(a)
     elif args.out == "ips":
         #get the IP addresses from our list of indicators
         ips = api_obj.GetIPsFromResults(data, related=args.related)
         uniqueIps = set(ips) #dedupe list
         for i in uniqueIps:
             #print one per line
-            print i
+            print(i)
     elif args.out == "IfReport":
         #print out the raw data, but only if there is an associated
         #report with it.
         for datum in data:
             if len(datum['reports']) > 0:
-                print datum
+                print(datum)
 
     else:
         #by default pretty print the whole JSON
         if args.raw == False:
             pprint.pprint( data )
         else:
-            print data
+            print(data)
 
 #EOF


### PR DESCRIPTION
This pull request provides python3 support, fixing issue #52, while still keeping backwards compatibility for python2.
To execute with python2:
```
python2 CSIntel.py --help
```
To execute with python3
```
./CSIntel.py --help
```

I also used the opportunity to do some code-tiding by adding [PEP8](https://www.python.org/dev/peps/pep-0008/) compliance (code guidelines). 

While doing this a minor bug was identified and fixed:
```raise Exception("Invalid Domain type: " + domain) ```	
was corrected to  
``` raise Exception("Invalid email type: " + email)```
